### PR TITLE
Implement GET and DELETE handlers for EntryConcepts

### DIFF
--- a/entryConcepts/EntryConceptHandler.py
+++ b/entryConcepts/EntryConceptHandler.py
@@ -1,1 +1,25 @@
 from helpers import BasicHandler
+from models import EntryConcept
+
+class EntryConceptHandler(BasicHandler):
+    def _get_all(self, cursor):
+        cursor.execute("""
+        SELECT 
+            ec.id,
+            ec.entryId,
+            ec.conceptId
+        FROM EntryConcepts ec
+        """)
+
+        results = cursor.fetchall()
+
+        entryConcepts = [ (EntryConcept(**entryConcept)).__dict__ for entryConcept in results ]
+
+        return entryConcepts
+
+    def _delete(self, cursor, id):
+        cursor.execute("""
+        DELETE
+        FROM EntryConcepts
+        WHERE id = ?
+        """, ( id, ))

--- a/entryConcepts/EntryConceptHandler.py
+++ b/entryConcepts/EntryConceptHandler.py
@@ -1,0 +1,1 @@
+from helpers import BasicHandler

--- a/entryConcepts/__init__.py
+++ b/entryConcepts/__init__.py
@@ -1,0 +1,1 @@
+from .EntryConceptHandler import EntryConceptHandler

--- a/models/EntryConcept.py
+++ b/models/EntryConcept.py
@@ -1,0 +1,5 @@
+class EntryConcept:
+    def __init__(self, id, entryId, conceptId):
+        self.id = id
+        self.entryId = entryId
+        self.conceptId = conceptId

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 from .Entry import Entry
 from .Mood import Mood
 from .Concept import Concept
+from .EntryConcept import EntryConcept

--- a/request_handler.py
+++ b/request_handler.py
@@ -5,6 +5,7 @@ import urllib
 from entries import EntryHandler
 from concepts import ConceptHandler
 from moods import MoodHandler
+from entryConcepts import EntryConceptHandler
 
 class HandleRequests(BaseHTTPRequestHandler):
     def _set_headers(self, status):
@@ -57,6 +58,8 @@ class HandleRequests(BaseHTTPRequestHandler):
             return ConceptHandler()
         elif resource == 'moods':
             return MoodHandler()
+        elif resource == 'entryConcepts':
+            return EntryConceptHandler()
         
         raise Exception('Unrecognized resource')
 


### PR DESCRIPTION
Implemented _get_all and _delete for EntryConceptHandler, as these are the only two (non-creation) methods needed for entry concept resources.