### PR TITLE
delete all associated EntryConcepts for the Entry being deleted

### DIFF
--- a/entries/EntryHandler.py
+++ b/entries/EntryHandler.py
@@ -88,3 +88,10 @@ class EntryHandler(BasicHandler):
         FROM Entries
         WHERE id = ?
         """, ( id, ))
+
+        # cascade delete all EntryConcepts that were associated with this entry
+        cursor.execute("""
+        DELETE
+        FROM EntryConcepts
+        WHERE entryId= ?
+        """, ( id, ))


### PR DESCRIPTION
When you delete an Entry, we should also delete all of the EntryConcept items associated with that Entry.